### PR TITLE
Delete param

### DIFF
--- a/libs/jumblr/src/main/java/com/tumblr/jumblr/types/Blog.java
+++ b/libs/jumblr/src/main/java/com/tumblr/jumblr/types/Blog.java
@@ -14,7 +14,6 @@ public class Blog extends Resource {
     private String description;
     private int posts, likes, followers;
     private Long updated;
-    private boolean ask, ask_anon;
 
     /**
      * Get the description of this blog
@@ -22,22 +21,6 @@ public class Blog extends Resource {
      */
     public String getDescription() {
         return this.description;
-    }
-
-    /**
-     * Can we ask questions on this blog?
-     * @return boolean
-     */
-    public boolean canAsk() {
-        return this.ask;
-    }
-
-    /**
-     * Can we ask questions on this blog anonymously?
-     * @return boolean
-     */
-    public boolean canAskAnonymously() {
-        return this.ask_anon;
     }
 
     /**


### PR DESCRIPTION
Delete unused param.
Sometimes `ask_anon` is returned as another type like `long` .
It will crash the app.